### PR TITLE
Spelling error, poorly named variable, bloat.

### DIFF
--- a/irc.js
+++ b/irc.js
@@ -130,7 +130,7 @@ client.addListener('message', function (from, to, message) {
     // moose was called too recently
     if (lastMessageAge < 25) {
         client.say(from, 'please wait another ' + (26 - lastMessageAge) + 
-                         ' seconds);
+                         ' seconds');
         return;
     }
 

--- a/irc.js
+++ b/irc.js
@@ -118,19 +118,19 @@ client.addListener('message', function (from, to, message) {
     // make sure only valid characters exist in the mooseme command
     var mooseMe = message.match(/^\.?moose(?:me)? ([A-z0-9 -_]+)/),
         bots = /^\.bots/.test(message),
-        remaining;
+        lastMessageAge;
 
     // message not from channel
     if (!/#/.test(to) || !(mooseMe || bots)) {
         return;
     }
 
-    remaining = Math.round((Date.now() - lastMessage) / 1000);
+    lastMessageAge = Math.round((Date.now() - lastMessage) / 1000);
 
-    // moose was called to recently
-    if (remaining < 25) {
-        client.say(from, 'please wait another ' + (25 - remaining) +
-                         ' second' + (remaining < 24 ? 's' : ''));
+    // moose was called too recently
+    if (lastMessageAge < 25) {
+        client.say(from, 'please wait another ' + (26 - lastMessageAge) + 
+                         ' seconds);
         return;
     }
 


### PR DESCRIPTION
I fixed grammatical / spelling error in a comment. "Too" not "to."
I changed a poorly named variable. It's not the time remaining. The time remaining is 25 - the variable. It's the age of the last message. 
I removed bloat. A string manipulating ternary condition running every time a user is calling moose too often is more than likely exploitable, and absolutely a bad thing in it's own right.

`NOTE: I haven't tested these changes, and it appears you don't have tests set up in the repo. You should consider that or run whatever ones you have locally.`
